### PR TITLE
test(integration): add microsoft/skills repo to integration tests

### DIFF
--- a/integration_tests/scripts/runner.sh
+++ b/integration_tests/scripts/runner.sh
@@ -122,7 +122,7 @@ echo "Scenario 11: Installing real skills from microsoft/skills via GitHub URL..
 caf skills add https://github.com/microsoft/skills --yes --force || { echo -e "${RED}Failed to add microsoft/skills via URL${NC}"; exit 1; }
 
 echo "Verifying microsoft-skills installation..."
-caf skills list | grep "azure-cosmos-db-py" || { echo -e "${RED}microsoft-skills verification failed${NC}"; exit 1; }
+caf skills list | grep "github-skills-azure-cosmos-db-py" || { echo -e "${RED}microsoft-skills verification failed${NC}"; exit 1; }
 
 # 12. Remove a skill
 echo "Scenario 12: Removing a skill..."

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -7,8 +7,10 @@ import {
   extractCategories,
   generateSmartName,
   safeJoin,
+  isExcludedName,
   LOCK_FILE_VERSION,
   CORE_RESOURCE_TYPES,
+  EXCLUDE_PATTERNS,
 } from './index.js';
 
 describe('@coding-agent-fabric/common', () => {
@@ -103,6 +105,46 @@ describe('@coding-agent-fabric/common', () => {
 
     it('should have correct core resource types', () => {
       expect(CORE_RESOURCE_TYPES).toEqual(['skills', 'subagents', 'rules']);
+    });
+  });
+
+  describe('isExcludedName', () => {
+    it('should match exact patterns', () => {
+      expect(isExcludedName('node_modules', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('.git', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('dist', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('build', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('.DS_Store', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('.env', EXCLUDE_PATTERNS)).toBe(true);
+    });
+
+    it('should NOT match substrings for exact patterns', () => {
+      // .github should NOT be excluded by .git pattern (regression test)
+      expect(isExcludedName('.github', EXCLUDE_PATTERNS)).toBe(false);
+      // something-dist should NOT be excluded by dist pattern
+      expect(isExcludedName('something-dist', EXCLUDE_PATTERNS)).toBe(false);
+      // node_modules_backup should NOT be excluded
+      expect(isExcludedName('node_modules_backup', EXCLUDE_PATTERNS)).toBe(false);
+    });
+
+    it('should match wildcard prefix patterns (*.ext)', () => {
+      expect(isExcludedName('error.log', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('debug.log', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('app.log', EXCLUDE_PATTERNS)).toBe(true);
+    });
+
+    it('should match wildcard suffix patterns (prefix.*)', () => {
+      expect(isExcludedName('.env.local', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('.env.production', EXCLUDE_PATTERNS)).toBe(true);
+      expect(isExcludedName('.env.development', EXCLUDE_PATTERNS)).toBe(true);
+    });
+
+    it('should NOT match unrelated names', () => {
+      expect(isExcludedName('src', EXCLUDE_PATTERNS)).toBe(false);
+      expect(isExcludedName('package.json', EXCLUDE_PATTERNS)).toBe(false);
+      expect(isExcludedName('SKILL.md', EXCLUDE_PATTERNS)).toBe(false);
+      expect(isExcludedName('.claude', EXCLUDE_PATTERNS)).toBe(false);
+      expect(isExcludedName('skills', EXCLUDE_PATTERNS)).toBe(false);
     });
   });
 });

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -266,6 +266,34 @@ export async function retry<T>(
 }
 
 /**
+ * Check if a filename should be excluded based on EXCLUDE_PATTERNS.
+ * Handles exact matches and simple wildcard patterns (*.ext, prefix.*).
+ */
+export function isExcludedName(name: string, patterns: readonly string[]): boolean {
+  for (const pattern of patterns) {
+    // Wildcard at start: *.log matches error.log
+    if (pattern.startsWith('*')) {
+      const suffix = pattern.slice(1);
+      if (name.endsWith(suffix)) {
+        return true;
+      }
+    }
+    // Wildcard at end: .env.* matches .env.local
+    else if (pattern.endsWith('*')) {
+      const prefix = pattern.slice(0, -1);
+      if (name.startsWith(prefix)) {
+        return true;
+      }
+    }
+    // Exact match
+    else if (name === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Sanitize a file name (remove invalid characters and prevent path traversal)
  */
 export function sanitizeFileName(name: string): string {

--- a/packages/core/src/rules-handler.ts
+++ b/packages/core/src/rules-handler.ts
@@ -25,6 +25,7 @@ import {
   RULE_FILE_EXTENSIONS,
   generateSmartName,
   sanitizeFileName,
+  isExcludedName,
 } from '@coding-agent-fabric/common';
 import { ResourceHandler } from '@coding-agent-fabric/plugin-api';
 import { AgentRegistry } from './agent-registry.js';
@@ -394,7 +395,7 @@ export class RulesHandler implements ResourceHandler {
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
 
-      if (EXCLUDE_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+      if (isExcludedName(entry.name, EXCLUDE_PATTERNS)) {
         continue;
       }
 

--- a/packages/core/src/skills-handler.ts
+++ b/packages/core/src/skills-handler.ts
@@ -28,6 +28,7 @@ import {
   generateSmartName,
   sanitizeFileName,
   safeJoin,
+  isExcludedName,
 } from '@coding-agent-fabric/common';
 import { ResourceHandler } from '@coding-agent-fabric/plugin-api';
 import { AgentRegistry } from './agent-registry.js';
@@ -409,7 +410,7 @@ export class SkillsHandler implements ResourceHandler {
       const fullPath = join(dir, entry.name);
 
       // Skip excluded patterns
-      if (EXCLUDE_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+      if (isExcludedName(entry.name, EXCLUDE_PATTERNS)) {
         continue;
       }
 
@@ -483,7 +484,7 @@ export class SkillsHandler implements ResourceHandler {
       const fullPath = join(dir, entry.name);
 
       // Skip excluded patterns
-      if (EXCLUDE_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+      if (isExcludedName(entry.name, EXCLUDE_PATTERNS)) {
         continue;
       }
 

--- a/packages/core/src/subagents-handler.ts
+++ b/packages/core/src/subagents-handler.ts
@@ -25,6 +25,7 @@ import {
   EXCLUDE_PATTERNS,
   sanitizeFileName,
   safeJoin,
+  isExcludedName,
 } from '@coding-agent-fabric/common';
 import { ResourceHandler } from '@coding-agent-fabric/plugin-api';
 import { AgentRegistry } from './agent-registry.js';
@@ -459,7 +460,7 @@ export class SubagentsHandler implements ResourceHandler {
       const fullPath = join(dir, entry.name);
 
       // Skip excluded patterns
-      if (EXCLUDE_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+      if (isExcludedName(entry.name, EXCLUDE_PATTERNS)) {
         continue;
       }
 
@@ -609,7 +610,7 @@ export class SubagentsHandler implements ResourceHandler {
       const fullPath = join(dir, entry.name);
 
       // Skip excluded patterns
-      if (EXCLUDE_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+      if (isExcludedName(entry.name, EXCLUDE_PATTERNS)) {
         continue;
       }
 


### PR DESCRIPTION
### **User description**
Add microsoft/skills repo as a test case for skills discovery in deeply
nested directories (skills are under .github/skills/ with language-based
organization). Renumber subsequent test scenarios accordingly.

https://claude.ai/code/session_01DdLdBdZbVFhm62N5MNbWi2


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix EXCLUDE_PATTERNS substring matching bug causing `.github` to be incorrectly excluded

- Add `isExcludedName()` utility function supporting exact and wildcard pattern matching

- Add comprehensive unit tests for the new exclusion matching function

- Add integration test for microsoft/skills repo with nested directory structure

- Renumber integration test scenarios to reflect new test case


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EXCLUDE_PATTERNS<br/>substring bug"] -->|"Fix with<br/>exact matching"| B["isExcludedName()<br/>utility function"]
  B -->|"Used by"| C["SkillsHandler"]
  B -->|"Used by"| D["SubagentsHandler"]
  B -->|"Used by"| E["RulesHandler"]
  F["microsoft/skills<br/>integration test"] -->|"Tests nested<br/>directory discovery"| G["Integration<br/>test suite"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add isExcludedName utility for pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/common/src/utils.ts

<ul><li>Add <code>isExcludedName()</code> function that properly handles exact matches, <br>wildcard prefix patterns (*.ext), and wildcard suffix patterns <br>(prefix.*)<br> <li> Replace substring matching logic with proper pattern matching to fix <br><code>.github</code> false exclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-5d5884b9358d068a91886a9b4dd88e013da5162a9b31187a166afced7c4f9d0e">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>skills-handler.ts</strong><dd><code>Use isExcludedName for pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/skills-handler.ts

<ul><li>Replace <code>EXCLUDE_PATTERNS.some((pattern) => </code><br><code>entry.name.includes(pattern))</code> with <code>isExcludedName(entry.name, </code><br><code>EXCLUDE_PATTERNS)</code> in two locations<br> <li> Update pattern matching in <code>findSkillDirs()</code> and <code>collectSkillFiles()</code> <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-ec358410c1e9d49d0a75429ba96127fd012bb71a5b16a3156244b43886fad040">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subagents-handler.ts</strong><dd><code>Use isExcludedName for pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/subagents-handler.ts

<ul><li>Replace substring-based pattern matching with <code>isExcludedName()</code> <br>function in two locations<br> <li> Update pattern matching in <code>findSubagentDirs()</code> and <br><code>collectSubagentFiles()</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-6adf508847a35d16da2041d8ae6113e45ff93a71e7f1042fd841e6b38eb1394b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rules-handler.ts</strong><dd><code>Use isExcludedName for pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/rules-handler.ts

<ul><li>Replace substring-based pattern matching with <code>isExcludedName()</code> <br>function<br> <li> Update pattern matching in <code>findRuleFiles()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-b956c8b35ad27b0a1864122050d9402f7bb3ab6d69ee16be47e553b2e2c459df">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add isExcludedName unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/common/src/index.test.ts

<ul><li>Add comprehensive unit tests for <code>isExcludedName()</code> covering exact <br>matches, wildcard patterns, and edge cases<br> <li> Test regression case where <code>.github</code> should not be excluded by <code>.git</code> <br>pattern<br> <li> Test that unrelated names are not matched</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-e0b19e7b1da4142bd18731485073f4bf2109684975c962ca9c718661595b384c">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runner.sh</strong><dd><code>Add microsoft/skills integration test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integration_tests/scripts/runner.sh

<ul><li>Add Scenario 11 to test microsoft/skills installation via GitHub URL <br>with nested directory structure under <code>.github/skills/</code><br> <li> Verify installation by checking for <code>github-skills-azure-cosmos-db-py</code> <br>skill<br> <li> Renumber all subsequent test scenarios (12-18) to accommodate new test <br>case</ul>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/coding-agent-fabric/pull/10/files#diff-284695f34632e6d7d1c5dc2f6dc5bf2d1f7ff983256d4a5dceb231337650b428">+21/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

